### PR TITLE
Fix ShowNotification its order of the arguments

### DIFF
--- a/legacy/Client/functions/shownotification.md
+++ b/legacy/Client/functions/shownotification.md
@@ -1,7 +1,7 @@
 # ShowNotification
 
 ```lua
-ESX.ShowNotification(msg, time, type)
+ESX.ShowNotification(msg, type, time)
 ```
 
 ## Example 
@@ -38,8 +38,8 @@ This function shows a notification to the player.
 | Argument      | Data Type | Optional | Default Value | Explanation                                                                                       |
 |---------------|-----------|----------|---------------|---------------------------------------------------------------------------------------------------|
 | msg           | string    | No       | -             | The message to display                                                                            |
-| time          | number    | Yes      | 3000          | For how long the notification should show                                                         |
 | Type          | string    | Yes      | "info"        | What type the notification would be                                                               |
+| time          | number    | Yes      | 3000          | For how long the notification should show                                                         |
 
 
  


### PR DESCRIPTION
It should be [ msg, type, time ] instead of [ msg, time, type ]. This error will make some scripts that followed this recipe don't work.