### PR TITLE
Remove Reference to Dead Domain Partner "17MOV"

### DIFF
--- a/src/theme/Partner/index.js
+++ b/src/theme/Partner/index.js
@@ -25,16 +25,6 @@ function Partners() {
             <span className="btn">10% off with ESX code</span>
           </a>
         </li>
-
-        <li className="background-box">
-          <a href="https://store.17mov.pro/">
-            <img
-              className="logo-partner"
-              src="https://esx.s3.fr-par.scw.cloud/17movement.png"
-            />
-            <span className="btn">10% off with ESX code</span>
-          </a>
-        </li>
       </ul>
     </section>
   );


### PR DESCRIPTION
The domain for Partner 17MOV is inactive and does not provide any services or promotions towards ESX users.
Except to purchase the domain.